### PR TITLE
I added a "fix" for the cssRules issue & support for a transformFunction

### DIFF
--- a/src/css-global-variables.js
+++ b/src/css-global-variables.js
@@ -160,9 +160,7 @@ const CSSGlobalVariables = function( { filterSelector, autoPrefix, transformFunc
     function normalizeVariableName( name = '' ){
         name = String(name);
         if( __config__.transformFunc !== null ){
-            console.log('name before transformFunc:',name)
             name = __config__.transformFunc( name )
-            console.log('name after transformFunc:',name)
         }
         if( name.substring(0,2) !=='--' ){
             if(__config__.autoPrefix ) name = '--' + name;


### PR DESCRIPTION
Hey!

As I understand, it is not possible to access the css-rules of an external css-sheet(Cross-Origin) but it's not really possible to make a distinction when iterating over all stylesheets. Maybe there is, or there will  a better way, but right now, try/catch atleast works. ¯\_(ツ)_/¯

I extended the config by a user-provided transform-function, that processes the property names before they get autoPrefixed inside normalizeVariableName().
A user can provide a custom function, or one from a library like [change-case](https://www.npmjs.com/package/change-case), eg paramCase, camelCase, etc, so that hyphenated css-vars can still be accessed via dot-notation.

When I added this optional config property, I also changed the param to the CSSGlobalVariables function from multi-param to param-object, so that specific config properties can be provided on initialization, without the need to pass unchanged default values along.

I never made a commit to someone else's project, so I hope I did not make any unforgivable mistakes. If so, please let me know!

Best Regards